### PR TITLE
overflowing_literals false positive

### DIFF
--- a/src/float_pt.rs
+++ b/src/float_pt.rs
@@ -164,9 +164,9 @@ mod tests {
 
     #[test]
     #[should_panic]
+    #[allow(overflowing_literals)]
     fn expect_one_in_ho_fail() {
         // 0x80000000 is defaulted to a i32 thus the answer is -1
-        #[allow(overflowing_literals)]
         assert_eq!(1, 0x80000000 >> 31)
     }
 


### PR DESCRIPTION
In a future version of Rust the `overflowing_literals` lint will become deny by default. See rust-lang/rust#55632. When checking for breakage in crates uploaded to crates.io it was discovered that this crate will no longer compile thanks to this lint. The error produced is [here](https://crater-reports.s3.amazonaws.com/pr-55632/try%23dc13be39fae8d4c607889b27de374b52586485a3/gh/excelciordan.rust_float_pt/log.txt). This PR should fix the false positive.